### PR TITLE
Fix `Program<T>` equality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,6 @@ impl Instruction {
                     SourceDest::Dest => 1,
                 };
                 result.push(mode * 64 + reg * 8 + rm);
-                println!(">  {}, {}", offset % 256, offset / 256);
                 result.push((offset % 256) as u8);
                 result.push((offset / 256) as u8);
             }
@@ -369,7 +368,6 @@ impl Instruction {
                 result
             }
             Instruction::MemRegMove(mov) => {
-                println!("Instruction: {}", self);
                 let mut result = Vec::with_capacity(2);
 
                 let instruction1 = 0b10001000u8;
@@ -380,7 +378,6 @@ impl Instruction {
 
                 Self::push_effective_address(&mov.source, dest_reg, &mut result);
 
-                println!("{:?}", result);
                 result
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,6 +551,7 @@ impl Instruction {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub struct Program<T>
 where
     T: AsRef<[Instruction]>,
@@ -558,30 +559,6 @@ where
     bits: u8,
     instructions: T,
 }
-
-impl<T> PartialEq for Program<T>
-where
-    T: AsRef<[Instruction]>,
-{
-    fn eq(&self, other: &Self) -> bool {
-        if self.bits != other.bits {
-            return false;
-        };
-        let iter1 = self.instructions.as_ref();
-        let iter2 = self.instructions.as_ref();
-        if iter1.len() != iter2.len() {
-            return false;
-        }
-
-        if !iter1.iter().zip(iter2.iter()).all(|(x, y)| x == y) {
-            return false;
-        }
-
-        true
-    }
-}
-
-impl<T> Eq for Program<T> where T: AsRef<[Instruction]> {}
 
 impl<T> Display for Program<T>
 where
@@ -681,10 +658,27 @@ fn main() {
 mod test_program {
     use crate::{
         register::{GeneralRegister, Register, RegisterSubset},
-        Instruction, MemRegMove, Program,
+        ImmediateToRegister, Instruction, MemRegMove, Program,
     };
 
     use super::assembly::program;
+
+    #[test]
+    fn test_programs_with_different_instruction_sequences_are_not_equal() {
+        let program1 = Program {
+            bits: 64,
+            instructions: vec![],
+        };
+        let program2 = Program {
+            bits: 64,
+            instructions: vec![Instruction::ImmediateToRegister(ImmediateToRegister::Byte(
+                Register::General(GeneralRegister::D, RegisterSubset::All),
+                1,
+            ))],
+        };
+
+        assert_ne!(program1, program2);
+    }
 
     fn test_parser<T>(input_asm: &str, input_bytecode: T)
     where

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,7 +658,7 @@ fn main() {
 mod test_program {
     use crate::{
         register::{GeneralRegister, Register, RegisterSubset},
-        ImmediateToRegister, Instruction, MemRegMove, Program,
+        ImmediateToRegister, Instruction, MemRegMove, Program, SourceDest, Base,
     };
 
     use super::assembly::program;
@@ -821,5 +821,14 @@ mod test_program {
             dest: Register::General(GeneralRegister::D, RegisterSubset::All),
         });
         assert_eq!(i.to_bytes(), vec![139, 86, 0]);
+    }
+
+    #[test]
+    fn mem_reg_move_sum_to_bytes() {
+        let i = Instruction::MemRegMove(MemRegMove {
+            source: crate::EffectiveAddress::Sum(crate::WithOffset::WithU16((Base::Bx, SourceDest::Source), 4999)),
+            dest: Register::General(GeneralRegister::D, RegisterSubset::All),
+        });
+        assert_eq!(i.to_bytes(), vec![138, 128, 135, 19]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -680,6 +680,26 @@ mod test_program {
         assert_ne!(program1, program2);
     }
 
+    #[test]
+    fn test_programs_with_identical_instruction_sequences_are_equal() {
+        let program1 = Program {
+            bits: 64,
+            instructions: vec![Instruction::ImmediateToRegister(ImmediateToRegister::Byte(
+                Register::General(GeneralRegister::D, RegisterSubset::All),
+                1,
+            ))],
+        };
+        let program2 = Program {
+            bits: 64,
+            instructions: vec![Instruction::ImmediateToRegister(ImmediateToRegister::Byte(
+                Register::General(GeneralRegister::D, RegisterSubset::All),
+                1,
+            ))],
+        };
+
+        assert_eq!(program1, program2);
+    }
+
     fn test_parser<T>(input_asm: &str, input_bytecode: T)
     where
         T: AsRef<[u8]>,


### PR DESCRIPTION
The version on `main` compares `self.instructions` to itself:

https://github.com/Smaug123/performance_aware_programming/blob/00d8fcf98d83c6a0ee2ec41aec9eabef95748fe1/src/main.rs#L570-L580